### PR TITLE
Fixed empty pagePathPrefix not redirecting

### DIFF
--- a/js/routing.js
+++ b/js/routing.js
@@ -5,14 +5,14 @@ module.exports = function() {
 	var emitter = new EventEmitter()
 
 	var satnav = Satnav({}).navigate({
-		path: '!/' + config.pagePathPrefix + '{name}',
-		directions: function(params) {
-			emitter.emit('current', params.name)
-		}
-	}).navigate({
 		path: '!/',
 		directions: function(params) {
 			emitter.emit('current', 'index.md')
+		}
+	}).navigate({
+		path: '!/' + config.pagePathPrefix + '{name}',
+		directions: function(params) {
+			emitter.emit('current', params.name)
 		}
 	}).navigate({
 		path: '',


### PR DESCRIPTION
When the pagePathPrefix is an empty string, clicking the logo did not redirect.
After I switched around 2 certain `.navigate()` commands, it worked as expected.
