### PR TITLE
Noddity now loads the template completely from a content file.

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,6 +6,6 @@ noddityConfig = {
 	errorPage: '404.md',
 	pathPrefix: '#!/',
 	pagePathPrefix: 'post/',
-	debug: false,
-	sidebar: null
+	template: 'template',
+	debug: false
 }

--- a/content/template
+++ b/content/template
@@ -1,0 +1,33 @@
+title: template
+markdown: false
+
+{{#editLink}}
+	<div id="edit-post-link"><a href="{{editLink}}{{current}}">Edit this post</a></div>
+{{/editLink}}
+
+<div id="sidebar">
+	<a href="./">
+		<img class="logo" src="{{logo}}" />
+	</a>
+	<div>
+		<h3>Posts</h3>
+		<ol>
+			{{#postList}}
+				<li><a href="{{pathPrefix}}{{pagePathPrefix}}{{filename}}">{{title}}</a></li>
+			{{/postList}}
+		</ol>
+	</div>
+</div>
+
+<div id="main">
+	<article>
+		<div>
+			{{#metadata.title}}
+				<h1>{{metadata.title}}</h1>
+			{{/metadata.title}}
+			<div class="post-content">
+				{{{html}}}
+			</div>
+		</div>
+	</article>
+</div>

--- a/index.html
+++ b/index.html
@@ -1,86 +1,51 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<title>
-		Noddity
-	</title>
-	<!--
-		If you want to enable an RSS feed for your site, uncomment this next line, and change the
-		arguments to point to your domain and have your name and blog title and stuff.
-	-->
-	<!-- <link href="http://seo.noddityaas.com/?noddityRoot=http://noddity.com/content/&postUrlRoot=http://noddity.com/%23!/post/&title=Noddity&author=TehShrike" rel="alternate" type="application/rss+xml" title="Noddity" /> -->
+	<head>
+		<title>
+			Noddity
+		</title>
+		<!--
+			If you want to enable an RSS feed for your site, uncomment this next line, and change the
+			arguments to point to your domain and have your name and blog title and stuff.
+		-->
+		<!-- <link href="http://seo.noddityaas.com/?noddityRoot=http://noddity.com/content/&postUrlRoot=http://noddity.com/%23!/post/&title=Noddity&author=TehShrike" rel="alternate" type="application/rss+xml" title="Noddity" /> -->
 
-	<!--
-		this next line tells search engine spiders that they should use _escaped_fragment_ urls
-		to find static versions of your pages.  Make sure that .htaccess file is working correctly
-		if you want to enable this.
-	-->
-	<!-- <meta name="fragment" content="!"> -->
+		<!--
+			this next line tells search engine spiders that they should use _escaped_fragment_ urls
+			to find static versions of your pages.  Make sure that .htaccess file is working correctly
+			if you want to enable this.
+		-->
+		<!-- <meta name="fragment" content="!"> -->
 
-	<meta charset="utf-8">
+		<meta charset="utf-8">
 
-	<link rel="stylesheet" type="text/css" href="fonts.css" />
-	<link rel="stylesheet" type="text/css" href="style.css" />
-	<link rel="shortcut icon" href="icon/favicon.ico">
-	<link rel="apple-touch-icon" sizes="57x57" href="icon/apple-touch-icon-57x57.png">
-	<link rel="apple-touch-icon" sizes="114x114" href="icon/apple-touch-icon-114x114.png">
-	<link rel="apple-touch-icon" sizes="72x72" href="icon/apple-touch-icon-72x72.png">
-	<link rel="apple-touch-icon" sizes="144x144" href="icon/apple-touch-icon-144x144.png">
-	<link rel="apple-touch-icon" sizes="60x60" href="icon/apple-touch-icon-60x60.png">
-	<link rel="apple-touch-icon" sizes="120x120" href="icon/apple-touch-icon-120x120.png">
-	<link rel="apple-touch-icon" sizes="76x76" href="icon/apple-touch-icon-76x76.png">
-	<link rel="apple-touch-icon" sizes="152x152" href="icon/apple-touch-icon-152x152.png">
-	<link rel="icon" type="image/png" href="icon/favicon-196x196.png" sizes="196x196">
-	<link rel="icon" type="image/png" href="icon/favicon-160x160.png" sizes="160x160">
-	<link rel="icon" type="image/png" href="icon/favicon-96x96.png" sizes="96x96">
-	<link rel="icon" type="image/png" href="icon/favicon-16x16.png" sizes="16x16">
-	<link rel="icon" type="image/png" href="icon/favicon-32x32.png" sizes="32x32">
-	<meta name="msapplication-TileColor" content="#2b5797">
-	<meta name="msapplication-TileImage" content="icon/mstile-144x144.png">
-	<meta name="msapplication-square70x70logo" content="icon/mstile-70x70.png">
-	<meta name="msapplication-square144x144logo" content="icon/mstile-144x144.png">
-	<meta name="msapplication-square150x150logo" content="icon/mstile-150x150.png">
-	<meta name="msapplication-square310x310logo" content="icon/mstile-310x310.png">
-	<meta name="msapplication-wide310x150logo" content="icon/mstile-310x150.png">
-</head>
+		<link rel="stylesheet" type="text/css" href="fonts.css" />
+		<link rel="stylesheet" type="text/css" href="style.css" />
+		<link rel="shortcut icon" href="icon/favicon.ico">
+		<link rel="apple-touch-icon" sizes="57x57" href="icon/apple-touch-icon-57x57.png">
+		<link rel="apple-touch-icon" sizes="114x114" href="icon/apple-touch-icon-114x114.png">
+		<link rel="apple-touch-icon" sizes="72x72" href="icon/apple-touch-icon-72x72.png">
+		<link rel="apple-touch-icon" sizes="144x144" href="icon/apple-touch-icon-144x144.png">
+		<link rel="apple-touch-icon" sizes="60x60" href="icon/apple-touch-icon-60x60.png">
+		<link rel="apple-touch-icon" sizes="120x120" href="icon/apple-touch-icon-120x120.png">
+		<link rel="apple-touch-icon" sizes="76x76" href="icon/apple-touch-icon-76x76.png">
+		<link rel="apple-touch-icon" sizes="152x152" href="icon/apple-touch-icon-152x152.png">
+		<link rel="icon" type="image/png" href="icon/favicon-196x196.png" sizes="196x196">
+		<link rel="icon" type="image/png" href="icon/favicon-160x160.png" sizes="160x160">
+		<link rel="icon" type="image/png" href="icon/favicon-96x96.png" sizes="96x96">
+		<link rel="icon" type="image/png" href="icon/favicon-16x16.png" sizes="16x16">
+		<link rel="icon" type="image/png" href="icon/favicon-32x32.png" sizes="32x32">
+		<meta name="msapplication-TileColor" content="#2b5797">
+		<meta name="msapplication-TileImage" content="icon/mstile-144x144.png">
+		<meta name="msapplication-square70x70logo" content="icon/mstile-70x70.png">
+		<meta name="msapplication-square144x144logo" content="icon/mstile-144x144.png">
+		<meta name="msapplication-square150x150logo" content="icon/mstile-150x150.png">
+		<meta name="msapplication-square310x310logo" content="icon/mstile-310x310.png">
+		<meta name="msapplication-wide310x150logo" content="icon/mstile-310x150.png">
+	</head>
 
-<body>
-<div id="sidebar"></div>
-<div id="main"></div>
+	<body></body>
 
-<script id='template-menu' type="text/ractive">
-	<a href="{{pathPrefix}}">
-		<img class="logo" src="{{logo}}" />
-	</a>
-
-	<div>
-		<h3>Posts</h3>
-		<ol>
-			{{#postList}}
-				<li><a href="{{pathPrefix}}{{pagePathPrefix}}{{filename}}">{{title}}</a></li>
-			{{/postList}}
-		</ol>
-	</div>
-</script>
-<script id="template-main" type="text/ractive">
-
-	{{#editLink}}<div id="edit-post-link"><a href="{{editLink}}{{current}}">Edit this post</a></div>{{/editLink}}
-	<article>
-		<div>
-			{{#metadata.title}}
-				<h1>{{metadata.title}}</h1>
-			{{/metadata.title}}
-			<div class="post-content">
-				{{{html}}}
-			</div>
-		</div>
-	</article>
-
-</script>
-
-<script src="config.js"></script>
-<script src="js/build.js"></script>
-
-</body>
-
+	<script src="config.js"></script>
+	<script src="js/build.js"></script>
 </html>

--- a/js/mainViewModel.js
+++ b/js/mainViewModel.js
@@ -78,7 +78,6 @@ module.exports = function MainViewModel(butler, linkifyEmitter, routingEmitter) 
 			}
 		})
 		butler.refreshPost(key)
-		butler.refreshPost(config.template)
 	}
 
 	linkifyEmitter.on('link', function(pageName) {

--- a/style.css
+++ b/style.css
@@ -1,8 +1,7 @@
-#sidebar {
-	float: left;
-	position: relative;
-	padding: 25px;
-	width: 300px;
+body {
+	min-width: 1110px;
+	color: #141414;
+	background-color: #FAFAFA;
 }
 
 #main {
@@ -12,19 +11,15 @@
 	width: 700px;
 }
 
-body {
+#sidebar {
 	float: left;
-	min-width: 1110px;
-	color: #141414;
-	background-color: #FAFAFA;
+	position: relative;
+	padding: 25px;
+	width: 300px;
 }
 
 #sidebar ol {
 	padding: 0;
-}
-
-#sidebar li a {
-	text-decoration: none;
 }
 
 #sidebar li {
@@ -32,6 +27,10 @@ body {
 	margin: 20px 0px;
 	line-height: 1.05;
 	list-style-type: none;
+}
+
+#sidebar li a {
+	text-decoration: none;
 }
 
 h1,h2,h3,h4,#sidebar a {
@@ -70,7 +69,7 @@ img.logo {
 	margin-right: auto;
 }
 
-div#edit-post-link {
+#edit-post-link {
 	position: absolute;
 	top: 2em;
 	right: 0;
@@ -81,7 +80,7 @@ div#edit-post-link {
 	-ms-transform:rotate(45deg);
 }
 
-div#edit-post-link a {
+#edit-post-link a {
 	text-decoration: none;
 	color: gray;
 }


### PR DESCRIPTION
Significant changes:

* There is no longer a sidebar vs main distinction
* That means every page gets the `postList` object as well
* Meaning the template just does things like `{{#postList}}<li>...` and `{{metadata.title}}` in the same ractive element, instead of separate ones
* If the template changes, the butler will update it silently in the background, just like a normal post

This implementation does not allow for the template to be split across several files. I believe this is probably ideal (for now) since having multiple template files means a network request for each file, increasing load time. Having the template in a separate network request already adds a bit of load time (50-300ms, depending on network), so we should minimize that as much as possible.