### PR TITLE
Use el.scrollToView() instead of scrollTo(0, el.offsetTop)

### DIFF
--- a/js/routing.js
+++ b/js/routing.js
@@ -48,6 +48,6 @@ module.exports = function() {
 function scrollToAnchor(anchor) {
 	var el = document.getElementById(anchor)
 	if (el) {
-		scrollTo(0, el.offsetTop)
+		el.scrollIntoView()
 	}
 }


### PR DESCRIPTION
scrollTo(0, el.offsetTop) doesn't work because some elements have incorrect
offsetTop properties.