### PR TITLE
Refresh the index.json on initial page load

### DIFF
--- a/js/mainViewModel.js
+++ b/js/mainViewModel.js
@@ -23,6 +23,8 @@ module.exports = function MainViewModel(butler, linkifyEmitter) {
 		}
 	}
 
+	butler.refreshIndex()
+
 	var titleRactive = new Ractive({
 		el: 'title',
 		template: '{{name}}{{#current.metadata.title}} | {{current.metadata.title}}{{/current.metadata.title}}'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fruitdown": "1.0.1",
     "hash-brown-router": "^1.3.3",
     "levelup": "~1.2.1",
-    "noddity-butler": "~2.4.0",
+    "noddity-butler": "^2.5.0",
     "noddity-linkifier": "~2.1.0",
     "noddity-render-dom": "^3.0.1",
     "pagedown": "~1.1.0",


### PR DESCRIPTION
I watched the XHR content in chrome:
- Before this change, the index.json was not requested upon initial page load.
- After this change, the index.json was requested upon initial page load.