### PR TITLE
Force noddity to use the latest renderer and butler

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "fruitdown": "1.0.1",
     "hash-brown-router": "^1.3.3",
     "levelup": "~1.2.1",
-    "noddity-butler": "^2.5.0",
+    "noddity-butler": "^2.6.0",
     "noddity-linkifier": "~2.1.0",
-    "noddity-render-dom": "^3.0.1",
+    "noddity-render-dom": "^3.1.0",
     "ractive": "~0.7.3",
     "subleveldown": "~2.1.0",
     "xtend": "4.0.1"


### PR DESCRIPTION
We should look into updating hash-brown-router, since we're requiring 1.3.3, and the latest is 3.0.0.
